### PR TITLE
Add __serialize/__unserialize

### DIFF
--- a/lib/Horde/Mime/Headers.php
+++ b/lib/Horde/Mime/Headers.php
@@ -388,15 +388,7 @@ implements ArrayAccess, IteratorAggregate, Serializable
      */
     public function serialize()
     {
-        $data = array(
-            // Serialized data ID.
-            self::VERSION,
-            $this->_headers->getArrayCopy(),
-            // TODO: BC
-            $this->_eol
-        );
-
-        return serialize($data);
+        return serialize($this->__serialize());
     }
 
     /**
@@ -409,8 +401,31 @@ implements ArrayAccess, IteratorAggregate, Serializable
     public function unserialize($data)
     {
         $data = @unserialize($data);
-        if (!is_array($data) ||
-            !isset($data[0]) ||
+        $this->__unserialize($data);
+    }
+
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        return array(
+            // Serialized data ID.
+            self::VERSION,
+            $this->_headers->getArrayCopy(),
+            // TODO: BC
+            $this->_eol
+        );
+    }
+
+    /**
+     * @param array $data
+     * @return void
+     * @throws Horde_Mime_Exception
+     */
+    public function __unserialize($data)
+    {
+        if (!isset($data[0]) ||
             ($data[0] != self::VERSION)) {
             throw new Horde_Mime_Exception('Cache version change');
         }

--- a/lib/Horde/Mime/Headers/ContentParam.php
+++ b/lib/Horde/Mime/Headers/ContentParam.php
@@ -404,11 +404,7 @@ implements ArrayAccess, Horde_Mime_Headers_Extension_Mime, Serializable
      */
     public function serialize()
     {
-        $vars = array_filter(get_object_vars($this));
-        if (isset($vars['_params'])) {
-            $vars['_params'] = $vars['_params']->getArrayCopy();
-        }
-        return serialize($vars);
+        return serialize($this->__serialize());
     }
 
     /**
@@ -417,15 +413,36 @@ implements ArrayAccess, Horde_Mime_Headers_Extension_Mime, Serializable
     {
         $data = unserialize($data);
 
+        $this->__unserialize($data);
+    }
+
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        $vars = array_filter(get_object_vars($this));
+        if (isset($vars['_params'])) {
+            $vars['_params'] = $vars['_params']->getArrayCopy();
+        }
+        return $vars;
+    }
+
+    /**
+     * @param array $data
+     * @return void
+     */
+    public function __unserialize($data)
+    {
         foreach ($data as $key => $val) {
             switch ($key) {
-            case '_params':
-                $this->_params = new Horde_Support_CaseInsensitiveArray($val);
-                break;
+                case '_params':
+                    $this->_params = new Horde_Support_CaseInsensitiveArray($val);
+                    break;
 
-            default:
-                $this->$key = $val;
-                break;
+                default:
+                    $this->$key = $val;
+                    break;
             }
         }
     }

--- a/lib/Horde/Mime/Part.php
+++ b/lib/Horde/Mime/Part.php
@@ -2393,6 +2393,24 @@ implements ArrayAccess, Countable, RecursiveIterator, Serializable
      */
     public function serialize()
     {
+        return serialize($this->__serialize());
+    }
+
+    /**
+     * Unserialization.
+     *
+     * @param string $data  Serialized data.
+     *
+     * @throws Exception
+     */
+    public function unserialize($data)
+    {
+        $data = @unserialize($data);
+        $this->__unserialize($data);
+    }
+
+    public function __serialize()
+    {
         $data = array(
             // Serialized data ID.
             self::VERSION,
@@ -2411,31 +2429,25 @@ implements ArrayAccess, Countable, RecursiveIterator, Serializable
             $data[] = $this->_readStream($this->_contents);
         }
 
-        return serialize($data);
+        return $data;
     }
 
     /**
-     * Unserialization.
-     *
-     * @param string $data  Serialized data.
-     *
-     * @throws Exception
+     * @param array $data
      */
-    public function unserialize($data)
+    public function __unserialize($data)
     {
-        $data = @unserialize($data);
-        if (!is_array($data) ||
-            !isset($data[0]) ||
+        if (!isset($data[0]) ||
             ($data[0] != self::VERSION)) {
             switch ($data[0]) {
-            case 1:
-                $convert = new Horde_Mime_Part_Upgrade_V1($data);
-                $data = $convert->data;
-                break;
+                case 1:
+                    $convert = new Horde_Mime_Part_Upgrade_V1($data);
+                    $data = $convert->data;
+                    break;
 
-            default:
-                $data = null;
-                break;
+                default:
+                    $data = null;
+                    break;
             }
 
             if (is_null($data)) {


### PR DESCRIPTION
> As of PHP 8.1.0, a class which implements Serializable without also implementing [__serialize()](https://www.php.net/manual/en/language.oop5.magic.php#object.serialize) and [__unserialize()](https://www.php.net/manual/en/language.oop5.magic.php#object.unserialize) will generate a deprecation warning.

@bytestream 

Upstream PR: https://github.com/horde/Stream/pull/1