### PR TITLE
fix: inconsistent encoding when getting raw messages - option a

### DIFF
--- a/lib/Horde/Mime/Mail.php
+++ b/lib/Horde/Mime/Mail.php
@@ -504,7 +504,7 @@ class Horde_Mime_Mail
             );
         }
 
-        return $this->_headers->toString() . $this->getBasePart()->toString();
+        return $this->_headers->toString() . $this->getBasePart()->toString(array('encode' => Horde_Mime_Part::ENCODE_7BIT | Horde_Mime_Part::ENCODE_8BIT | Horde_Mime_Part::ENCODE_BINARY));
     }
 
     /**


### PR DESCRIPTION
The encoding used in `getRaw() ` is inconsistent between calling it with stream=true and stream=false. I added the missing encode opts to make it consistent again.

See the code a few lines above my changes.