### PR TITLE
Inconsistent encoding when getting raw messages

### DIFF
--- a/lib/Horde/Mime/Mail.php
+++ b/lib/Horde/Mime/Mail.php
@@ -493,18 +493,11 @@ class Horde_Mime_Mail
      */
     public function getRaw($stream = true)
     {
-        if ($stream) {
-            $hdr = new Horde_Stream();
-            $hdr->add($this->_headers->toString(), true);
-            return Horde_Stream_Wrapper_Combine::getStream(
-                array($hdr->stream,
-                      $this->getBasePart()->toString(
-                        array('stream' => true, 'encode' => Horde_Mime_Part::ENCODE_7BIT | Horde_Mime_Part::ENCODE_8BIT | Horde_Mime_Part::ENCODE_BINARY))
-                )
-            );
-        }
-
-        return $this->_headers->toString() . $this->getBasePart()->toString();
+        return $this->getBasePart()->toString(array(
+            'stream' => $stream,
+            'encode' => Horde_Mime_Part::ENCODE_7BIT | Horde_Mime_Part::ENCODE_8BIT | Horde_Mime_Part::ENCODE_BINARY,
+            'headers' => $this->_headers,
+        ));
     }
 
     /**


### PR DESCRIPTION
My preferred alternative to #7.

I'm not sure about the impact on the rest of the code base but this approach fixes inconsistent encoding once and for all.