### PR TITLE
fix: rewind stream before returning it

### DIFF
--- a/lib/Horde/Mime/Mail.php
+++ b/lib/Horde/Mime/Mail.php
@@ -493,11 +493,17 @@ class Horde_Mime_Mail
      */
     public function getRaw($stream = true)
     {
-        return $this->getBasePart()->toString(array(
+        $raw = $this->getBasePart()->toString(array(
             'stream' => $stream,
             'encode' => Horde_Mime_Part::ENCODE_7BIT | Horde_Mime_Part::ENCODE_8BIT | Horde_Mime_Part::ENCODE_BINARY,
             'headers' => $this->_headers,
         ));
+
+        if ($stream && is_resource($raw)) {
+            rewind($raw);
+        }
+
+        return $raw;
     }
 
     /**


### PR DESCRIPTION
Follow-up to https://github.com/bytestream/Mime/pull/8

Hey again, I'm very sorry for introducing a bug in my last PR. 

Before my fix, the returned stream was always rewound before returning which is not the case anymore after my PR. So we are facing (kind of) a breaking API Change in a patch release.

Here is a little fix to restore consistency with the old behavior. I tested the code properly this time.

Thanks again for maintaining Horde code :)