### PR TITLE
Fix deprecation warnings on PHP >= 8.5

### DIFF
--- a/lib/Horde/Mime/Headers.php
+++ b/lib/Horde/Mime/Headers.php
@@ -130,6 +130,8 @@ implements ArrayAccess, IteratorAggregate, Serializable
             $tmp = array();
 
             foreach ($ob->sendEncode(array_filter($sopts)) as $val) {
+                $val = $val ?? '';
+
                 if (empty($opts['nowrap'])) {
                     /* Remove any existing linebreaks and wrap the line. */
                     $htext = $ob->name . ': ';
@@ -503,7 +505,7 @@ implements ArrayAccess, IteratorAggregate, Serializable
     #[ReturnTypeWillChange]
     public function getIterator()
     {
-        return new ArrayIterator($this->_headers);
+        return new ArrayIterator((array) $this->_headers);
     }
 
     /* Deprecated functions */

--- a/lib/Horde/Mime/Magic.php
+++ b/lib/Horde/Mime/Magic.php
@@ -164,7 +164,6 @@ class Horde_Mime_Magic
 
             if ($res) {
                 $type = trim(finfo_file($res, $path));
-                finfo_close($res);
 
                 /* Remove any additional information. */
                 if (empty($opts['nostrip'])) {
@@ -213,7 +212,6 @@ class Horde_Mime_Magic
             }
 
             $type = trim(finfo_buffer($res, $data));
-            finfo_close($res);
 
             /* Remove any additional information. */
             if (empty($opts['nostrip'])) {

--- a/lib/Horde/Mime/Part.php
+++ b/lib/Horde/Mime/Part.php
@@ -1124,12 +1124,14 @@ implements ArrayAccess, Countable, RecursiveIterator, Serializable
      * Get the transfer encoding for the part based on the user requested
      * transfer encoding and the current contents of the part.
      *
-     * @param integer $encode  A mask of allowable encodings.
+     * @param int|null $encode A mask of allowable encodings.
      *
      * @return string  The transfer-encoding of this part.
      */
-    protected function _getTransferEncoding($encode = self::ENCODE_7BIT)
+    protected function _getTransferEncoding(?int $encode)
     {
+        $encode = $encode ?? self::ENCODE_7BIT;
+
         if (!empty($this->_temp['sendEncoding'])) {
             return $this->_temp['sendEncoding'];
         } elseif (!empty($this->_temp['sendTransferEncoding'][$encode])) {


### PR DESCRIPTION
When running the unit tests for the Nextcloud mail app on PHP 8.5, the following deprecation warnings are being thrown:

```
PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/apps-extra/mail/vendor/bytestream/horde-mime/lib/Horde/Mime/Headers.php on line 139

PHP Deprecated:  ArrayIterator::__construct(): Using an object as a backing array for ArrayIterator is deprecated, as it allows violating class constraints and invariants in /home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/vendor/bytestream/horde-mime/lib/Horde/Mime/Headers.php on line 506

PHP Deprecated:  Using null as an array offset is deprecated, use an empty string instead in /var/www/html/apps-extra/mail/vendor/bytestream/horde-mime/lib/Horde/Mime/Part.php on line 1205
```

These issues are being mitigated by this PR.

When checking for additional deprecations, I've experienced that `finfo_close()` is [being deprecated as well](https://www.php.net/manual/de/migration85.deprecated.php#migration85.deprecated.fileinfo) as `finfo` objects are freed automatically. Therefore, I've removed those calls.

Relates to https://github.com/nextcloud/mail/issues/12384.